### PR TITLE
Add header function and prompt for the fish shell

### DIFF
--- a/fish_prompt/fish_prompt.fish
+++ b/fish_prompt/fish_prompt.fish
@@ -1,0 +1,21 @@
+function fish_prompt
+  set -l normal (set_color normal)
+
+  set -l color_cwd
+  set -l suffix
+  switch $USER
+    case root toor
+      if set -q fish_color_cwd_root
+        set color_cwd $fish_color_cwd_root
+      else
+        set color_cwd $fish_color_cwd
+      end
+      set suffix '#'
+    case '*'
+      set color_cwd $fish_color_cwd
+      set suffix '>'
+  end
+
+  echo -e -n -s (soji_header) "\n" (set_color "yellow") (soji status) " " (set_color $color_cwd) (prompt_pwd) $normal (__fish_git_prompt) "$suffix "
+
+end

--- a/fish_prompt/soji_header.fish
+++ b/fish_prompt/soji_header.fish
@@ -1,0 +1,63 @@
+function soji_header
+  set -l blue (set_color blue)
+  set todays_note_file (soji note-path log)
+
+  set -l color_cwd
+  set -l suffix
+  switch $USER
+    case root toor
+      if set -q fish_color_cwd_root
+        set color_cwd $fish_color_cwd_root
+      else
+        set color_cwd $fish_color_cwd
+      end
+      set suffix '#'
+    case '*'
+      set color_cwd $fish_color_cwd
+      set suffix '>'
+  end
+
+  set -l journal_color
+  set -l journal
+  if [ -e (soji note-path journal) ]
+    set journal "✔"
+    set journal_color (set_color "green")
+  else
+    set journal "✘"
+    set journal_color (set_color "red")
+  end
+
+  set -l meditation_color
+  set -l meditation
+  if cat $todays_note_file ^ /dev/null | grep -i "** Meditation" > /dev/null ^ /dev/null
+    set meditation "✔"
+    set meditation_color (set_color "green")
+  else
+    set meditation "✘"
+    set meditation_color (set_color "red")
+  end
+
+  set pom_count (cat $todays_note_file ^ /dev/null | grep -i "** start" | wc -l)
+  set -l poms_color
+  if [ "$pom_count" -lt 4 ]
+    set poms_color (set_color "red")
+  else if [ "$pom_count" -lt 8 ]
+    set poms_color (set_color "yellow")
+  else
+    set poms_color (set_color "green")
+  end
+
+  set -l lunch_color
+  set -l lunch
+  if cat $todays_note_file ^ /dev/null | grep -i "** lunch" > /dev/null ^ /dev/null
+    set lunch "✔"
+    set lunch_color (set_color "green")
+  else
+    set lunch "✘"
+    set lunch_color (set_color "red")
+  end
+
+  set meeting_count (cat $todays_note_file 2> /dev/null | grep -i "** meeting" | wc -l)
+
+  echo -e -s $blue "journal " $journal_color "$journal" $blue " meditation " $meditation_color "$meditation" $blue " lunch " $lunch_color "$lunch" $blue " pomodoros " $poms_color "$pom_count" $blue " meetings " (set_color "green") $meeting_count (set_color normal)
+end


### PR DESCRIPTION
The `soji header` function isn't compatible with the fish shell. It's
pretty typical in fish to encapsulate that kind of thing as a standalone
function which can be called from a prompt function, so that's what I've
done here. It should look very similar to `soji header`.

I wasn't sure where to put it so I created a directory in the root.

https://fishshell.com/