### PR TITLE
Adding ability to spawn callbacks from certain soji actions

### DIFF
--- a/subcommands/break
+++ b/subcommands/break
@@ -10,5 +10,4 @@ else
     crontab -l | { cat; echo "`date +'%M %H %d %m *' --date '+5 min'` soji bright"; } | crontab -
 fi
 
-
-
+soji callback "break"

--- a/subcommands/callback
+++ b/subcommands/callback
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+    echo "$0 <name-of-event>"
+    exit 1 
+fi
+
+CALLBACKS_HOME="${HOME}/.config/soji/callbacks/${1}" 
+shift
+
+if [ -d $CALLBACKS_HOME ]; then
+    for script in $CALLBACKS_HOME/*; do
+       $script $*
+    done
+fi

--- a/subcommands/lunch
+++ b/subcommands/lunch
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 soji log "lunch" "lunch"
+soji callback "lunch"

--- a/subcommands/meditate
+++ b/subcommands/meditate
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 soji log "meditation" "meditation"
+soji callback "meditation"

--- a/subcommands/meeting
+++ b/subcommands/meeting
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 soji log "meeting" "$1"
+soji callback "meeting"

--- a/subcommands/start
+++ b/subcommands/start
@@ -5,3 +5,4 @@ soji schedule_notification "20 min left! On the task $1" 5
 soji schedule_notification "15 min left! On the task $1" 10
 soji schedule_notification "10 min left! On the task $1" 15
 soji schedule_notification "ONLY 5 min left! On the task $1" 20
+soji callback start 25


### PR DESCRIPTION
the callbacks are placed in `~/.config/soji/callbacks/<event_name>`

the events supported
 * start
 * break
 * lunch
 * meeting
 * meditation