### PR TITLE
Making prompt customizable by decomposing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Soji is design to interact with you primarily through your command prompt (as pi
 The standard prompt setup is built into soji. You just need to add to you `.bashrc` or `.bash_profile`
 
 ```
-PROMPT_COMMAND='PS1="`soji header`"'
+PROMPT_COMMAND='PS1="`soji prompt`"'
 ```
 
 I use a very up to date version of GNU `bash`. I do not know if this will work with other shells, including `zsh`

--- a/subcommands/header
+++ b/subcommands/header
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-
-
 #prompt
 RED="\[\033[1;31m\]"
 YELLOW="\[\033[1;33m\]"
@@ -46,11 +44,4 @@ fi
 meeting_count=`cat $todays_note_file 2> /dev/null | grep -i "** meeting" | wc -l`
 meetings="$WHITE meetings $GREEN $meeting_count"
 
-#from Gary Bernhart
-gitbranch=""
-ref="$(git branch 2> /dev/null | sed -n "/*/ p" | awk '{ print $2 }')"
-if [ -n "$ref" ]; then
-  gitbranch="("${ref#refs/heads/}")"
-fi  
-
-echo "\n$journal $meditation $lunch $poms $meetings\n$RED \$(soji status) $YELLOW[\@] $RED\W $GREEN $gitbranch $RED$ $NOCOLOR"
+echo "$journal $meditation $lunch $poms $meetings"

--- a/subcommands/prompt
+++ b/subcommands/prompt
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+#prompt
+RED="\[\033[1;31m\]"
+YELLOW="\[\033[1;33m\]"
+GREEN="\[\033[1;32m\]"
+NOCOLOR="\[\033[1;0m\]"
+
+#from Gary Bernhart
+gitbranch=""
+ref="$(git branch 2> /dev/null | sed -n "/*/ p" | awk '{ print $2 }')"
+if [ -n "$ref" ]; then
+  gitbranch="("${ref#refs/heads/}")"
+fi  
+
+echo "\n$(soji header)\n$RED \$(soji status) $YELLOW[\@] $RED\W $GREEN $gitbranch $RED$ $NOCOLOR"


### PR DESCRIPTION
Introducing the subcommand `soji prompt` to generate the old prompt, and leaving only the actual header in 
`soji header`.